### PR TITLE
rsync -vr -> rsync -va

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ if [[ "$BRANCH" != "$DEFAULT_BRANCH" ]]; then
 fi
 
 echo "copying changes"
-rsync -vr --exclude='.git' ${CLEAN_REPO:+--delete} "$INPUT_CHANGES"/ repo
+rsync -va --exclude='.git' ${CLEAN_REPO:+--delete} "$INPUT_CHANGES"/ repo
 
 cd repo || exit 1
 


### PR DESCRIPTION
Fixes #3.

This change sets rsync to archive mode [equals -rlptgoD (no -H,-A,-X), per the man page], instead of just recursive mode.

This allows symbolic links, permissions, timestamps, and group/ownership to propagate correctly to the target repository.

Strictly speaking, I don't think the `-goD` parameters (group, ownership, and devices) are necessary here, but I don't see the harm either.